### PR TITLE
Fix refcounting mistake in TextInfo::jsonSerialize

### DIFF
--- a/src/php/classes/locale_text_info.c
+++ b/src/php/classes/locale_text_info.c
@@ -80,7 +80,6 @@ PHP_METHOD(Ecma_Intl_Locale_TextInfo, jsonSerialize) {
       *zend_read_property(ecma_ce_IntlLocaleTextInfo, object, "direction",
                           sizeof("direction") - 1, false, NULL);
   add_property_zval(return_value, "direction", &direction);
-  zval_ptr_dtor(&direction);
 }
 
 static void freeLocaleTextInfoObj(zend_object *object) {


### PR DESCRIPTION
read_property doesn't increase the refcount, add_property_zval does
if you do zval_ptr_dtor the refcount isn't right anymore