### PR TITLE
Fix installing with PECL

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -68,6 +68,10 @@ if test "$PHP_ECMA_INTL" != "no"; then
     cxx
   )
 
+  PHP_ADD_BUILD_DIR($ext_builddir/src/ecma402)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/php)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/php/classes)
+
   PHP_REQUIRE_CXX()
   PHP_CXX_COMPILE_STDCXX(11, mandatory, PHP_ECMA_INTL_STDCXX)
 


### PR DESCRIPTION
As detailed in https://github.com/php-ecma-intl/ext/issues/7, it's not possible to install the extension with PECL (and the new test introduced in #8 fails).

This PR fixes that issue (and #8 will suceed).

PS: Fix #7
