### PR TITLE
Allow PHP 8.3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -199,7 +199,7 @@ Fix: ensure build directories are created for each source directory, fixing an i
     <required>
       <php>
         <min>8.2.0</min>
-        <max>8.2.99</max>
+        <max>8.3.99</max>
       </php>
       <pearinstaller>
         <min>1.10.1</min>


### PR DESCRIPTION
As we are close to RC1 and final API

Build fine and test suite passes with master

```
=====================================================================
PHP         : /opt/php83/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.3.0-dev
ZEND_VERSION: 4.3.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.4.12-100.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Aug 23 17:49:27 UTC 2023 x86_64
INI actual  : /work/GIT/pecl-and-ext/ecma_intl/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/php83/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.3.0-dev
ZEND_VERSION: 4.3.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.4.12-100.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Aug 23 17:49:27 UTC 2023 x86_64
INI actual  : /work/GIT/pecl-and-ext/ecma_intl/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
---------------------------------------------------------------------
PHP         : /opt/php83/bin/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 8.3.0-dev
ZEND_VERSION: 4.3.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.4.12-100.fc37.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Aug 23 17:49:27 UTC 2023 x86_64
INI actual  : /work/GIT/pecl-and-ext/ecma_intl/tmp-php.ini
More .INIs  : 
---------------------------------------------------------------------
CWD         : /work/GIT/pecl-and-ext/ecma_intl
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2023-08-29 15:06:52
=====================================================================
PASS Intl cannot be instantiated [tests/phpt/Intl-001.phpt] 
PASS Category enum has expected values [tests/phpt/Intl/Category-001.phpt] 
PASS Locale casts to string [tests/phpt/Intl/Locale-001.phpt] 
PASS Locale accepts Stringable [tests/phpt/Intl/Locale-002.phpt] 
PASS Locale exports with properties [tests/phpt/Intl/Locale-003.phpt] 
PASS Locale serializes to JSON with properties [tests/phpt/Intl/Locale-004.phpt] 
PASS Locale properties are readonly [tests/phpt/Intl/Locale-005.phpt] 
PASS Locale can access each property [tests/phpt/Intl/Locale-006.phpt] 
PASS Locale must have a valid value [tests/phpt/Intl/Locale-007.phpt] 
PASS Locale with Options [tests/phpt/Intl/Locale-008.phpt] 
PASS Locale canonicalizes, minimizes, and maximizes (< ICU 73.1) [tests/phpt/Intl/Locale-009.phpt] 
SKIP Locale canonicalizes, minimizes, and maximizes (>= ICU 73.1) [tests/phpt/Intl/Locale-010.phpt] reason: : Test requires ICU 73.1 or later
PASS Locale::getCalendars() returns expected values [tests/phpt/Intl/Locale-getCalendars-001.phpt] 
PASS Locale::getCollations() returns expected values [tests/phpt/Intl/Locale-getCollations-001.phpt] 
PASS Locale::getCurrencies() returns expected values [tests/phpt/Intl/Locale-getCurrencies-001.phpt] 
PASS Locale::getHourCycles() returns expected values [tests/phpt/Intl/Locale-getHourCycles-001.phpt] 
PASS Locale::getNumberingSystems() returns expected values [tests/phpt/Intl/Locale-getNumberingSystems-001.phpt] 
PASS Locale::getTextInfo() returns expected values [tests/phpt/Intl/Locale-getTextInfo-001.phpt] 
PASS Locale::getTimeZones() returns expected values [tests/phpt/Intl/Locale-getTimeZones-001.phpt] 
PASS Locale::getWeekInfo() returns expected values [tests/phpt/Intl/Locale-getWeekInfo-001.phpt] 
PASS Locale::toString() returns expected values [tests/phpt/Intl/Locale-toString-001.phpt] 
PASS CharacterDirection enum has expected values [tests/phpt/Intl/Locale/CharacterDirection-001.phpt] 
PASS Options without any parameters serializes to empty JSON object [tests/phpt/Intl/Locale/Options-001.phpt] 
PASS Options with all parameters serializes to full JSON object [tests/phpt/Intl/Locale/Options-002.phpt] 
PASS Options can access each property [tests/phpt/Intl/Locale/Options-003.phpt] 
PASS Options can set each property to null [tests/phpt/Intl/Locale/Options-004.phpt] 
PASS Options can set combinations of properties [tests/phpt/Intl/Locale/Options-005.phpt] 
PASS Options properties are readonly [tests/phpt/Intl/Locale/Options-006.phpt] 
PASS Options throws exceptions for invalid values [tests/phpt/Intl/Locale/Options-007.phpt] 
PASS Options can be combined with array unpacking [tests/phpt/Intl/Locale/Options-008.phpt] 
PASS Options with stringable parameters [tests/phpt/Intl/Locale/Options-009.phpt] 
PASS Options allows boolean false for caseFirst [tests/phpt/Intl/Locale/Options-010.phpt] 
PASS Options propagates exceptions thrown from stringable conversion [tests/phpt/Intl/Locale/Options-011.phpt] 
PASS Options throws the first encountered stringable conversion exception [tests/phpt/Intl/Locale/Options-012.phpt] 
PASS TextInfo creation and JSON serialization [tests/phpt/Intl/Locale/TextInfo-001.phpt] 
PASS TextInfo properties are readonly [tests/phpt/Intl/Locale/TextInfo-002.phpt] 
PASS WeekDay enum has expected values [tests/phpt/Intl/Locale/WeekDay-001.phpt] 
PASS WeekInfo creation and JSON serialization [tests/phpt/Intl/Locale/WeekInfo-001.phpt] 
PASS WeekInfo property accessors [tests/phpt/Intl/Locale/WeekInfo-002.phpt] 
PASS WeekInfo constructor exceptions [tests/phpt/Intl/Locale/WeekInfo-003.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes string values [tests/phpt/Intl_getCanonicalLocales-001.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes array values [tests/phpt/Intl_getCanonicalLocales-002.phpt] 
PASS Intl::getCanonicalLocales() throws TypeError for non-string element [tests/phpt/Intl_getCanonicalLocales-003.phpt] 
PASS Intl::getCanonicalLocales() throws ValueError for invalid tag string [tests/phpt/Intl_getCanonicalLocales-004.phpt] 
PASS Intl::getCanonicalLocales() throws ValueError for invalid tag in array [tests/phpt/Intl_getCanonicalLocales-005.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes Generator values [tests/phpt/Intl_getCanonicalLocales-006.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes Iterator values [tests/phpt/Intl_getCanonicalLocales-007.phpt] 
PASS Intl::getCanonicalLocales() throws TypeError for invalid value in Generator [tests/phpt/Intl_getCanonicalLocales-008.phpt] 
PASS Intl::getCanonicalLocales() throws TypeError for invalid value in Iterator [tests/phpt/Intl_getCanonicalLocales-009.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes Stringable values [tests/phpt/Intl_getCanonicalLocales-010.phpt] 
PASS Intl::getCanonicalLocales() canonicalizes implicit Stringable values [tests/phpt/Intl_getCanonicalLocales-011.phpt] 
PASS Intl::supportedValuesOf(calendar) returns values [tests/phpt/Intl_supportedValuesOf-calendar-001.phpt] 
PASS Intl::supportedValuesOf(calendar) is sorted and unique [tests/phpt/Intl_supportedValuesOf-calendar-002.phpt] 
PASS Intl::supportedValuesOf(calendar) returns only strings [tests/phpt/Intl_supportedValuesOf-calendar-003.phpt] 
PASS Intl::supportedValuesOf(collation) returns values [tests/phpt/Intl_supportedValuesOf-collation-001.phpt] 
PASS Intl::supportedValuesOf(collation) must not include "search" or "standard" [tests/phpt/Intl_supportedValuesOf-collation-002.phpt] 
PASS Intl::supportedValuesOf(collation) is sorted and unique [tests/phpt/Intl_supportedValuesOf-collation-003.phpt] 
PASS Intl::supportedValuesOf(collation) returns only strings [tests/phpt/Intl_supportedValuesOf-collation-004.phpt] 
PASS Intl::supportedValuesOf(currency) returns values [tests/phpt/Intl_supportedValuesOf-currency-001.phpt] 
PASS Intl::supportedValuesOf(currency) is sorted and unique [tests/phpt/Intl_supportedValuesOf-currency-002.phpt] 
PASS Intl::supportedValuesOf(currency) returns only uppercase strings [tests/phpt/Intl_supportedValuesOf-currency-003.phpt] 
PASS Intl::supportedValuesOf(numberingSystem) returns values [tests/phpt/Intl_supportedValuesOf-numberingSystem-001.phpt] 
PASS Intl::supportedValuesOf(numberingSystem) is sorted and unique [tests/phpt/Intl_supportedValuesOf-numberingSystem-002.phpt] 
PASS Intl::supportedValuesOf(timeZone) returns values [tests/phpt/Intl_supportedValuesOf-timeZone-001.phpt] 
PASS Intl::supportedValuesOf(timeZone) is sorted and unique [tests/phpt/Intl_supportedValuesOf-timeZone-002.phpt] 
PASS Intl::supportedValuesOf(unit) returns sanctioned values [tests/phpt/Intl_supportedValuesOf-unit-001.phpt] 
PASS Intl::supportedValuesOf(unit) is sorted and unique [tests/phpt/Intl_supportedValuesOf-unit-002.phpt] 
=====================================================================
TIME END 2023-08-29 15:06:54

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    37
---------------------------------------------------------------------

Number of tests :    67                66
Tests skipped   :     1 (  1.5%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :    66 ( 98.5%) (100.0%)
---------------------------------------------------------------------
Time taken      :     2 seconds
=====================================================================

```