### PR TITLE
Fix build warning: control reaches end of non-void function

### DIFF
--- a/src/php/classes/locale.c
+++ b/src/php/classes/locale.c
@@ -519,7 +519,7 @@ static UCalendarDaysOfWeek weekDayEcmaToIcu(ecma402_dayOfWeek day) {
     return UCAL_FRIDAY;
   case ECMA402_SATURDAY:
     return UCAL_SATURDAY;
-  case ECMA402_SUNDAY:
+  default:
     return UCAL_SUNDAY;
   }
 }
@@ -538,7 +538,7 @@ static ecma402_dayOfWeek weekDayIcuToEcma(UCalendarDaysOfWeek day) {
     return ECMA402_FRIDAY;
   case UCAL_SATURDAY:
     return ECMA402_SATURDAY;
-  case UCAL_SUNDAY:
+  default:
     return ECMA402_SUNDAY;
   }
 }


### PR DESCRIPTION
```
libtool: compile:  cc -I. -I/work/GIT/pecl-and-ext/ecma_intl -I/work/GIT/pecl-and-ext/ecma_intl/include -I/work/GIT/pecl-and-ext/ecma_intl/main -I/work/GIT/pecl-and-ext/ecma_intl -I/opt/remi/php82/root/usr/include/php -I/opt/remi/php82/root/usr/include/php/main -I/opt/remi/php82/root/usr/include/php/TSRM -I/opt/remi/php82/root/usr/include/php/Zend -I/opt/remi/php82/root/usr/include/php/ext -I/opt/remi/php82/root/usr/include/php/ext/date/lib -I/work/GIT/pecl-and-ext/ecma_intl/src -DHAVE_CONFIG_H -O2 -Wp,-D_FORTIFY_SOURCE=2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -DZEND_COMPILE_DL_EXT=1 -c /work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c -MMD -MF src/php/classes/locale.dep -MT src/php/classes/locale.lo  -fPIC -DPIC -o src/php/classes/.libs/locale.o
/work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c: In function 'weekDayEcmaToIcu':
/work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c:525:1: warning: control reaches end of non-void function [-Wreturn-type]
  525 | }
      | ^
/work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c: In function 'weekDayIcuToEcma':
/work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c:544:1: warning: control reaches end of non-void function [-Wreturn-type]
  544 | }
      | ^
In file included from /work/GIT/pecl-and-ext/ecma_intl/src/php/php_common.h:25,
                 from /work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.h:16,
                 from /work/GIT/pecl-and-ext/ecma_intl/src/php/classes/locale.c:13:

```