### PR TITLE
feat: add support for the supportedLocalesOf() static methods

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: '
 -hicpp-*,
 -llvm-else-after-return,
 -llvm-header-guard,
+-llvm-include-order,
 -llvmlibc-*,
 -misc-unused-parameters,
 -modernize-macro-to-enum,

--- a/config.m4
+++ b/config.m4
@@ -42,6 +42,7 @@ if test "$PHP_ECMA_INTL" != "no"; then
     src/ecma402/numbering_system.c                                             \
     src/ecma402/time_zone.c                                                    \
     src/php/classes/category.c                                                 \
+    src/php/classes/collator.c                                                 \
     src/php/classes/intl.c                                                     \
     src/php/classes/locale.c                                                   \
     src/php/classes/locale_character_direction.c                               \
@@ -52,6 +53,7 @@ if test "$PHP_ECMA_INTL" != "no"; then
     src/php/classes/options.c                                                  \
     src/php/classes/supported_locales_options.c                                \
     src/php/ecma_intl.c                                                        \
+    src/php/supported_locales.c                                                \
     "
 
   PHP_ECMA_INTL_CXX_SOURCES="                                                  \

--- a/config.m4
+++ b/config.m4
@@ -50,6 +50,7 @@ if test "$PHP_ECMA_INTL" != "no"; then
     src/php/classes/locale_week_day.c                                          \
     src/php/classes/locale_week_info.c                                         \
     src/php/classes/options.c                                                  \
+    src/php/classes/supported_locales_options.c                                \
     src/php/ecma_intl.c                                                        \
     "
 

--- a/docs/readthedocs/reference.rst
+++ b/docs/readthedocs/reference.rst
@@ -15,3 +15,4 @@ Reference
    reference/ecma-intl-locale-textinfo
    reference/ecma-intl-locale-weekday
    reference/ecma-intl-locale-weekinfo
+   reference/ecma-intl-supportedlocales-options

--- a/docs/readthedocs/reference.rst
+++ b/docs/readthedocs/reference.rst
@@ -9,6 +9,7 @@ Reference
 
    reference/ecma-intl
    reference/ecma-intl-category
+   reference/ecma-intl-collator
    reference/ecma-intl-locale
    reference/ecma-intl-locale-characterdirection
    reference/ecma-intl-locale-options

--- a/docs/readthedocs/reference/ecma-intl-collator.rst
+++ b/docs/readthedocs/reference/ecma-intl-collator.rst
@@ -1,0 +1,18 @@
+.. _ecma.intl.collator:
+
+====================
+Ecma\\Intl\\Collator
+====================
+
+.. php:namespace:: Ecma\Intl
+.. php:class:: Collator
+
+    .. php:staticmethod:: supportedLocalesOf($locales[, $options = null]): string[]
+
+        Returns an array of those locales provided that are supported by this
+        implementation without having to fall back to the default locale.
+
+        :param iterable<Stringable|string> | Stringable | string | null $locales: One
+            or more language tags to check for support.
+        :param Ecma\\Intl\\SupportedLocales\\Options $options: Options to use when
+            evaluating supported locales.

--- a/docs/readthedocs/reference/ecma-intl-supportedlocales-options.rst
+++ b/docs/readthedocs/reference/ecma-intl-supportedlocales-options.rst
@@ -1,0 +1,47 @@
+.. _ecma.intl.supportedlocales.options:
+
+=====================================
+Ecma\\Intl\\SupportedLocales\\Options
+=====================================
+
+.. php:namespace:: Ecma\Intl\SupportedLocales
+.. php:class:: Options
+
+    Options to use when evaluating supported locales.
+
+    ECMA-402 defines a ``supportedLocalesOf()`` static method that is available
+    on many of the classes provided in the specification. For example, see
+    `Intl.Collator.supportedLocalesOf <https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof>`_.
+    Each of these methods accepts an ``options`` object that specifies the
+    locale matcher algorithm to use when evaluating supported locales. In this
+    PHP implementation, :php:class:`Ecma\\Intl\\SupportedLocales\\Options` provides
+    a type for this options object.
+
+    .. php:attr:: localeMatcher: string | null, readonly
+
+        The locale-matching algorithm to use when evaluating supported locales.
+
+    .. php:method:: __construct([$localeMatcher = null])
+
+        :param Stringable | string | null $localeMatcher: The locale-matching
+            algorithm to use when evaluating supported locales. This may be one
+            of the values ``"best fit"`` or ``"lookup"``. Other implementations
+            may define additional values.
+
+    .. php:method:: jsonSerialize(): object
+
+        Returns an object of these options, suitable for serializing to JSON.
+
+        Please note that any options with a ``null`` value will not be included
+        in the object this method returns. This allows the JSON to be passed to
+        JavaScript contexts, where these properties are considered ``undefined``.
+
+    .. php:method:: current(): string | bool
+
+    .. php:method:: next(): void
+
+    .. php:method:: key(): string
+
+    .. php:method:: valid(): bool
+
+    .. php:method:: rewind(): void

--- a/package.xml
+++ b/package.xml
@@ -79,6 +79,10 @@ Add Locale::$currency and Locale\Options::$currency properties. ECMA-402 does no
             <file name="category.h" role="src"/>
             <file name="category.stub.php" role="src"/>
             <file name="category_arginfo.h" role="src"/>
+            <file name="collator.c" role="src"/>
+            <file name="collator.h" role="src"/>
+            <file name="collator.stub.php" role="src"/>
+            <file name="collator_arginfo.h" role="src"/>
             <file name="intl.c" role="src"/>
             <file name="intl.h" role="src"/>
             <file name="intl.stub.php" role="src"/>
@@ -109,10 +113,16 @@ Add Locale::$currency and Locale\Options::$currency properties. ECMA-402 does no
             <file name="locale_week_info_arginfo.h" role="src"/>
             <file name="options.c" role="src"/>
             <file name="options.h" role="src"/>
+            <file name="supported_locales_options.c" role="src"/>
+            <file name="supported_locales_options.h" role="src"/>
+            <file name="supported_locales_options.stub.php" role="src"/>
+            <file name="supported_locales_options_arginfo.h" role="src"/>
           </dir>
           <file name="ecma_intl.c" role="src"/>
           <file name="ecma_intl.h" role="src"/>
           <file name="php_common.h" role="src"/>
+          <file name="supported_locales.c" role="src"/>
+          <file name="supported_locales.h" role="src"/>
         </dir>
       </dir>
       <dir name="tests">
@@ -153,6 +163,17 @@ Add Locale::$currency and Locale\Options::$currency properties. ECMA-402 does no
         <dir name="phpt">
           <dir name="Intl">
             <file name="Category-001.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-001.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-002.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-003.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-004.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-005.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-006.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-007.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-008.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-009.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-010.phpt" role="test"/>
+            <file name="Collator_supportedLocalesOf-011.phpt" role="test"/>
             <dir name="Locale">
               <file name="CharacterDirection-001.phpt" role="test"/>
               <file name="Options-001.phpt" role="test"/>
@@ -195,6 +216,18 @@ Add Locale::$currency and Locale\Options::$currency properties. ECMA-402 does no
             <file name="Locale-getTimeZones-001.phpt" role="test"/>
             <file name="Locale-getWeekInfo-001.phpt" role="test"/>
             <file name="Locale-toString-001.phpt" role="test"/>
+            <dir name="SupportedLocales">
+              <file name="Options-001.phpt" role="test"/>
+              <file name="Options-002.phpt" role="test"/>
+              <file name="Options-003.phpt" role="test"/>
+              <file name="Options-004.phpt" role="test"/>
+              <file name="Options-005.phpt" role="test"/>
+              <file name="Options-006.phpt" role="test"/>
+              <file name="Options-007.phpt" role="test"/>
+              <file name="Options-008.phpt" role="test"/>
+              <file name="Options-009.phpt" role="test"/>
+              <file name="Options-010.phpt" role="test"/>
+            </dir>
           </dir>
           <file name="Intl-001.phpt" role="test"/>
           <file name="Intl_getCanonicalLocales-001.phpt" role="test"/>

--- a/src/ecma402/locale.cpp
+++ b/src/ecma402/locale.cpp
@@ -479,8 +479,7 @@ int ecma402_intlAvailableLocales(char **locales)
 
 	for (i = 0; i < count; i++) {
 		char *locale = (char *)malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
-		languageTagForLocaleId(uloc_getAvailable(i), locale, status);
-		if (strcmp(locale, "") != 0) {
+		if (languageTagForLocaleId(uloc_getAvailable(i), locale, status) > 0) {
 			locales[counted] = strdup(locale);
 			counted++;
 		}

--- a/src/ecma402/locale.cpp
+++ b/src/ecma402/locale.cpp
@@ -39,6 +39,7 @@
 		int const len_##property = ecma402_##method(id, property, locale->status, true);                               \
 		if (ecma402_hasError(locale->status)) {                                                                        \
 			free(property);                                                                                            \
+			free(id);                                                                                                  \
 			return locale;                                                                                             \
 		}                                                                                                              \
 		if (len_##property >= 0) {                                                                                     \

--- a/src/ecma402/locale.cpp
+++ b/src/ecma402/locale.cpp
@@ -61,6 +61,7 @@ namespace {
 	                bool isCanonicalized);
 	int getNumberingSystemsForLocale(char *localeId, const char **values);
 	int getTimeZonesForLocale(char *localeId, const char **values);
+	int languageTagForLocaleId(const char *localeId, char *languageTag, ecma402_errorStatus *status);
 
 } // namespace
 
@@ -173,11 +174,6 @@ int ecma402_canonicalizeLocaleList(const char **locales, int localesLength, char
 
 int ecma402_canonicalizeUnicodeLocaleId(const char *localeId, char *canonicalized, ecma402_errorStatus *status)
 {
-	icu::Locale canonicalLocale;
-	UErrorCode icuStatus = U_ZERO_ERROR;
-	UBool const strict = 1;
-	char *unicodeLocaleId;
-
 	if (localeId == nullptr) {
 		return -1;
 	}
@@ -187,47 +183,7 @@ int ecma402_canonicalizeUnicodeLocaleId(const char *localeId, char *canonicalize
 		return -1;
 	}
 
-	canonicalLocale = icu::Locale::createCanonical(localeId);
-	if (canonicalLocale == nullptr) {
-		ecma402_ecmaError(status, CANNOT_CREATE_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
-		return -1;
-	}
-
-	std::string const locale = canonicalLocale.toLanguageTag<std::string>(icuStatus);
-	if (U_FAILURE(icuStatus) != U_ZERO_ERROR) {
-		ecma402_icuError(status, icuStatus, "Invalid language tag \"%s\"", localeId);
-		return -1;
-	}
-
-	// If the input localeId is not "und," but we got "und," then return 0.
-	if (strcasecmp(locale.c_str(), UNDETERMINED_LANGUAGE) == 0 && strcasecmp(localeId, UNDETERMINED_LANGUAGE) != 0) {
-		ecma402_ecmaError(status, UNDEFINED_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
-		return -1;
-	}
-
-	// This additional conversion step forces tags like "en-latn-us-co-foo" and
-	// "de-de_euro" to result in failures, which is the desired result.
-	unicodeLocaleId = (char *)malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
-	int const length = uloc_toLanguageTag(locale.c_str(), unicodeLocaleId, ULOC_FULLNAME_CAPACITY, strict, &icuStatus);
-
-	if (U_FAILURE(icuStatus) != U_ZERO_ERROR || strlen(unicodeLocaleId) == 0 || unicodeLocaleId == nullptr) {
-		if (U_FAILURE(icuStatus) != U_ZERO_ERROR) {
-			ecma402_icuError(status, icuStatus, "Invalid language tag \"%s\"", localeId);
-		} else {
-			ecma402_ecmaError(status, INVALID_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
-		}
-
-		if (unicodeLocaleId != nullptr) {
-			free(unicodeLocaleId);
-		}
-
-		return -1;
-	}
-
-	memcpy(canonicalized, unicodeLocaleId, length + 1);
-	free(unicodeLocaleId);
-
-	return length;
+	return languageTagForLocaleId(localeId, canonicalized, status);
 }
 
 void ecma402_freeLocale(ecma402_locale *locale)
@@ -458,6 +414,25 @@ ecma402_locale *ecma402_initLocale(const char *localeId)
 	free(canonical);
 
 	return locale;
+}
+
+int ecma402_intlAvailableLocales(char **locales)
+{
+	ecma402_errorStatus *status = ecma402_initErrorStatus();
+	const int count = uloc_countAvailable();
+	int i, counted = 0;
+
+	for (i = 0; i < count; i++) {
+		char *locale = (char *)malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
+		languageTagForLocaleId(uloc_getAvailable(i), locale, status);
+		if (strcmp(locale, "") != 0) {
+			locales[counted] = strdup(locale);
+			counted++;
+		}
+		free(locale);
+	}
+
+	return counted;
 }
 
 bool ecma402_isNumeric(const char *localeId, ecma402_errorStatus *status, bool isCanonicalized)
@@ -835,6 +810,58 @@ namespace {
 		free(region);
 
 		return count;
+	}
+
+	int languageTagForLocaleId(const char *localeId, char *languageTag, ecma402_errorStatus *status)
+	{
+		icu::Locale canonicalLocale;
+		UErrorCode icuStatus = U_ZERO_ERROR;
+		UBool const strict = 1;
+		char *unicodeLocaleId;
+
+		canonicalLocale = icu::Locale::createCanonical(localeId);
+		if (canonicalLocale == nullptr) {
+			ecma402_ecmaError(status, CANNOT_CREATE_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
+			return -1;
+		}
+
+		std::string const locale = canonicalLocale.toLanguageTag<std::string>(icuStatus);
+		if (U_FAILURE(icuStatus) != U_ZERO_ERROR) {
+			ecma402_icuError(status, icuStatus, "Invalid language tag \"%s\"", localeId);
+			return -1;
+		}
+
+		// If the input localeId is not "und," but we got "und," then return 0.
+		if (strcasecmp(locale.c_str(), UNDETERMINED_LANGUAGE) == 0 &&
+		    strcasecmp(localeId, UNDETERMINED_LANGUAGE) != 0) {
+			ecma402_ecmaError(status, UNDEFINED_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
+			return -1;
+		}
+
+		// This additional conversion step forces tags like "en-latn-us-co-foo" and
+		// "de-de_euro" to result in failures, which is the desired result.
+		unicodeLocaleId = (char *)malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
+		int const length =
+			uloc_toLanguageTag(locale.c_str(), unicodeLocaleId, ULOC_FULLNAME_CAPACITY, strict, &icuStatus);
+
+		if (U_FAILURE(icuStatus) != U_ZERO_ERROR || strlen(unicodeLocaleId) == 0 || unicodeLocaleId == nullptr) {
+			if (U_FAILURE(icuStatus) != U_ZERO_ERROR) {
+				ecma402_icuError(status, icuStatus, "Invalid language tag \"%s\"", localeId);
+			} else {
+				ecma402_ecmaError(status, INVALID_LOCALE_ID, "Invalid language tag \"%s\"", localeId);
+			}
+
+			if (unicodeLocaleId != nullptr) {
+				free(unicodeLocaleId);
+			}
+
+			return -1;
+		}
+
+		memcpy(languageTag, unicodeLocaleId, length + 1);
+		free(unicodeLocaleId);
+
+		return length;
 	}
 
 } // namespace

--- a/src/ecma402/locale.h
+++ b/src/ecma402/locale.h
@@ -253,6 +253,24 @@ int ecma402_getCaseFirst(const char *localeId, char *caseFirst, ecma402_errorSta
  */
 int ecma402_getCollation(const char *localeId, char *collation, ecma402_errorStatus *status, bool isCanonicalized);
 
+/**
+ * Returns the value of the currency (cu) keyword for the given locale ID.
+ *
+ * The currency parameter should already be allocated on the stack with
+ * enough memory to store the buffer. Typically, this should use
+ * ULOC_KEYWORDS_CAPACITY. For example:
+ *
+ *     malloc(sizeof(char) * ULOC_KEYWORDS_CAPACITY)
+ *
+ * @param localeId The locale identifier to get the currency value of.
+ * @param currency A buffer in which to store the currency value.
+ * @param status A status object to pass error messages back to the caller.
+ * @param isCanonicalized Whether localeId is already canonicalized. If not,
+ * this function will call ecma402_canonicalizeUnicodeLocaleId on localeId.
+ *
+ * @return The length of the string stored to the currency buffer, or -1 if the
+ * localeId has no currency value.
+ */
 int ecma402_getCurrency(const char *localeId, char *currency, ecma402_errorStatus *status, bool isCanonicalized);
 
 /**
@@ -370,6 +388,22 @@ ecma402_locale *ecma402_initEmptyLocale(void);
  * @param localeId The locale identifier, e.g., "en-US."
  */
 ecma402_locale *ecma402_initLocale(const char *localeId);
+
+/**
+ * Returns a list of locales available to this implementation.
+ *
+ * The locales parameter should already be allocated on the stack with
+ * enough memory to store the buffer. Typically, this should use
+ * uloc_countAvailable(). For example:
+ *
+ *     malloc(sizeof(char *) * uloc_countAvailable())
+ *
+ * @param locales A pointer in which to store the resulting char array of
+ * available locales.
+ *
+ * @return The number of items stored to the locales array.
+ */
+int ecma402_intlAvailableLocales(char **locales);
 
 /**
  * Returns true if the localeId has the colnumeric (kn) keyword with a value

--- a/src/ecma402/locale.h
+++ b/src/ecma402/locale.h
@@ -126,6 +126,31 @@ ecma402_locale *ecma402_applyLocaleOptions(ecma402_locale *locale, const char *c
                                            const char *region, const char *script);
 
 /**
+ * Returns the best available supported locale for the locale identifier given.
+ *
+ * The bestAvailable parameter should already be allocated on the stack with
+ * enough memory to store the buffer. Typically, this should use
+ * ULOC_FULLNAME_CAPACITY. For example:
+ *
+ *     malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY)
+ *
+ * @link https://tc39.github.io/ecma402/#sec-bestavailablelocale
+ *
+ * @param availableLocales A list of available locales, possibly generated from
+ * ecma402_intlAvailableLocales.
+ * @param availableLocalesCount The number of items in availableLocales.
+ * @param localeId The locale identifier to get the best available locale for.
+ * @param bestAvailable A buffer in which to store the best available locale.
+ * @param isCanonicalized Whether localeId is already canonicalized. If not,
+ * this function will call ecma402_canonicalizeUnicodeLocaleId on localeId.
+ *
+ * @return The length of the string stored to the bestAvailable buffer, or -1 if
+ * no best available supported locale is found.
+ */
+int ecma402_bestAvailableLocale(char **availableLocales, int availableLocalesCount, const char *localeId,
+                                char *bestAvailable, bool isCanonicalized);
+
+/**
  * Canonicalizes a list of locales.
  *
  * The canonicalized parameter should already be allocated on the stack with

--- a/src/php/classes/collator.c
+++ b/src/php/classes/collator.c
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#include "php/classes/collator.h"
+
+#include "ecma402/error.h"
+#include "php/supported_locales.h"
+
+#include "php/classes/collator_arginfo.h"
+
+#include <ext/spl/spl_iterators.h>
+
+zend_class_entry *ecma_ce_IntlCollator = NULL;
+zend_object_handlers ecma_handlers_IntlCollator;
+
+static void freeCollatorObj(zend_object *object);
+
+PHP_MINIT_FUNCTION(ecma_intl_collator)
+{
+	ecma_ce_IntlCollator = register_class_Ecma_Intl_Collator();
+	ecma_ce_IntlCollator->create_object = ecma_createIntlCollator;
+#if PHP_VERSION_ID >= 80300
+	ecma_ce_IntlCollator->default_object_handlers = &ecma_handlers_IntlCollator;
+#endif
+
+	memcpy(&ecma_handlers_IntlCollator, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+
+	ecma_handlers_IntlCollator.offset = XtOffsetOf(ecma_IntlCollator, std);
+	ecma_handlers_IntlCollator.free_obj = freeCollatorObj;
+
+	return SUCCESS;
+}
+
+zend_object *ecma_createIntlCollator(zend_class_entry *classEntry)
+{
+	ecma_IntlCollator *intlCollator;
+
+	intlCollator = zend_object_alloc(sizeof(struct ecma_IntlCollator), classEntry);
+
+	zend_object_std_init(&intlCollator->std, classEntry);
+	object_properties_init(&intlCollator->std, classEntry);
+
+#if PHP_VERSION_ID < 80300
+	intlCollator->std.handlers = &ecma_handlers_IntlCollator;
+#endif
+
+	return &intlCollator->std;
+}
+
+PHP_METHOD(Ecma_Intl_Collator, supportedLocalesOf)
+{
+	return ecma_supportedLocalesOf(execute_data, return_value);
+}
+
+static void freeCollatorObj(zend_object *object)
+{
+	ecma_IntlCollator *intlCollator = ecma_IntlCollatorFromObj(object);
+	zend_object_std_dtor(&intlCollator->std);
+}

--- a/src/php/classes/collator.h
+++ b/src/php/classes/collator.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#ifndef ECMA_INTL_PHP_CLASSES_COLLATOR_H
+#define ECMA_INTL_PHP_CLASSES_COLLATOR_H
+
+#include "php/php_common.h"
+
+typedef struct ecma_IntlCollator {
+	zend_object std;
+} ecma_IntlCollator;
+
+static inline ecma_IntlCollator *ecma_IntlCollatorFromObj(zend_object *obj)
+{
+	return (ecma_IntlCollator *)((char *)(obj)-XtOffsetOf(ecma_IntlCollator, std));
+}
+
+#define ECMA_COLLATOR_P(zv) ecma_IntlCollatorFromObj(Z_OBJ_P(zv))
+
+extern zend_class_entry *ecma_ce_IntlCollator;
+extern zend_object_handlers ecma_handlers_IntlCollator;
+
+zend_object *ecma_createIntlCollator(zend_class_entry *classEntry);
+
+PHP_MINIT_FUNCTION(ecma_intl_collator);
+
+#endif /* ECMA_INTL_PHP_CLASSES_COLLATOR_H */

--- a/src/php/classes/collator.stub.php
+++ b/src/php/classes/collator.stub.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ *
+ * @generate-class-entries
+ */
+
+namespace Ecma\Intl
+{
+    /**
+     * @strict-properties
+     */
+    readonly class Collator
+    {
+        /**
+         * Returns an array of those locales provided that are supported by this
+         * implementation without having to fall back to the default locale.
+         *
+         * @phpstan-param iterable<\Stringable|string>|\Stringable|string|null $locales One or more language tags to check for support.
+         * @param SupportedLocales\Options|null $options Options to use when evaluating supported locales.
+         *
+         * @return string[]
+         */
+        public static function supportedLocalesOf(iterable|\Stringable|string|null $locales, SupportedLocales\Options $options = null): array
+        {
+        }
+    }
+}

--- a/src/php/classes/collator_arginfo.h
+++ b/src/php/classes/collator_arginfo.h
@@ -1,0 +1,27 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 8a3332b06d2eaa035c994427e73148c4391d1572 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Ecma_Intl_Collator_supportedLocalesOf, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, locales, Traversable|Stringable, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_NULL, NULL)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, options, Ecma\\Intl\\SupportedLocales\\Options, 0, "null")
+ZEND_END_ARG_INFO()
+
+
+ZEND_METHOD(Ecma_Intl_Collator, supportedLocalesOf);
+
+
+static const zend_function_entry class_Ecma_Intl_Collator_methods[] = {
+	ZEND_ME(Ecma_Intl_Collator, supportedLocalesOf, arginfo_class_Ecma_Intl_Collator_supportedLocalesOf, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Ecma_Intl_Collator(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Ecma\\Intl", "Collator", class_Ecma_Intl_Collator_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_READONLY_CLASS;
+
+	return class_entry;
+}

--- a/src/php/classes/locale_options.c
+++ b/src/php/classes/locale_options.c
@@ -248,49 +248,9 @@ static void setNumeric(zend_object *object, bool numeric, bool isNumericNull)
 static bool setProperty(const char *name, zend_object *object, zend_string *valueStr, zend_object *valueObj,
                         bool (*validator)(const char *))
 {
-	const char *value;
-	const size_t length = strlen(name);
 	zend_class_entry *ce = ecma_ce_IntlLocaleOptions;
-	zval tmp;
-	bool destroyTmp = false;
 
-	if (valueStr == NULL && valueObj == NULL) {
-		zend_update_property_null(ce, object, name, length);
-
-		return true;
-	}
-
-	if (valueStr != NULL) {
-		value = ZSTR_VAL(valueStr);
-	} else {
-		zend_std_cast_object_tostring(valueObj, &tmp, IS_STRING);
-
-		if (EG(exception)) {
-			// We return true in order to bubble-up the exception thrown when casting
-			// the object to a string. If we returned false, the calling code would
-			// assume property validation failed and throw a ValueError instead.
-			return true;
-		}
-
-		value = Z_STRVAL(tmp);
-		destroyTmp = true;
-	}
-
-	if (validator(value)) {
-		zend_update_property_string(ce, object, name, length, value);
-
-		if (destroyTmp) {
-			zval_ptr_dtor(&tmp);
-		}
-
-		return true;
-	}
-
-	if (destroyTmp) {
-		zval_ptr_dtor(&tmp);
-	}
-
-	return false;
+	return setStringPropertyFromStringOrStringable(ce, object, name, valueStr, valueObj, validator);
 }
 
 static void setRegion(zend_object *object, zend_string *paramStr, zend_object *paramObj)

--- a/src/php/classes/options.c
+++ b/src/php/classes/options.c
@@ -100,6 +100,44 @@ void ecma_getCurrentOptionValue(zval *rv, zval *object, bool allowNull)
 	}
 }
 
+int ecma_getOptionBool(zend_class_entry *ce, zend_object *options, const char *name)
+{
+	zval *option, rv;
+
+	if (options == NULL) {
+		return -1;
+	}
+
+	option = zend_read_property(ce, options, name, strlen(name), false, &rv);
+
+	if (Z_TYPE_P(option) == IS_TRUE) {
+		return true;
+	}
+
+	if (Z_TYPE_P(option) == IS_FALSE) {
+		return false;
+	}
+
+	return -1;
+}
+
+const char *ecma_getOptionString(zend_class_entry *ce, zend_object *options, const char *name)
+{
+	zval *option, rv;
+
+	if (options == NULL) {
+		return NULL;
+	}
+
+	option = zend_read_property(ce, options, name, strlen(name), false, &rv);
+
+	if (Z_TYPE_P(option) == IS_STRING) {
+		return Z_STRVAL_P(option);
+	}
+
+	return NULL;
+}
+
 void ecma_nextOption(zval *object, bool allowNull)
 {
 	HashTable *ht = HASH_OF(object);

--- a/src/php/classes/options.h
+++ b/src/php/classes/options.h
@@ -37,4 +37,28 @@ void ecma_getCurrentOptionValue(zval *rv, zval *object, bool allowNull);
 void ecma_nextOption(zval *object, bool allowNull);
 void ecma_rewindOptions(zval *object);
 
+/**
+ * Returns the boolean value of the named option or -1 if the value is not set
+ * or is not boolean.
+ *
+ * @param ce The class type of the options object.
+ * @param options The options object.
+ * @param name The name of the option to retrieve.
+ *
+ * @return Boolean true (1) or false (0), or -1 if not set or not a boolean.
+ */
+int ecma_getOptionBool(zend_class_entry *ce, zend_object *options, const char *name);
+
+/**
+ * Returns the string value of the named option or NULL if the value is not set
+ * or is not a string.
+ *
+ * @param ce The class type of the options object.
+ * @param options The options object.
+ * @param name The name of the option to retrieve.
+ *
+ * @return The string value of the option, or NULL if not set or not a string.
+ */
+const char *ecma_getOptionString(zend_class_entry *ce, zend_object *options, const char *name);
+
 #endif /* ECMA_INTL_PHP_CLASSES_OPTIONS_H */

--- a/src/php/classes/supported_locales_options.c
+++ b/src/php/classes/supported_locales_options.c
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#include "php/classes/supported_locales_options.h"
+
+#include "php/classes/supported_locales_options_arginfo.h"
+
+#include <ext/json/php_json.h>
+#include <Zend/zend_interfaces.h>
+
+zend_class_entry *ecma_ce_IntlSupportedLocalesOptions = NULL;
+
+static bool isLocaleMatcherAlgorithm(const char *value);
+static void setLocaleMatcher(zend_object *object, zend_string *paramStr, zend_object *paramObj);
+
+PHP_MINIT_FUNCTION(ecma_intl_supported_locales_options)
+{
+	ecma_ce_IntlSupportedLocalesOptions =
+		register_class_Ecma_Intl_SupportedLocales_Options(zend_ce_iterator, php_json_serializable_ce);
+	ecma_ce_IntlSupportedLocalesOptions->create_object = ecma_createIntlOptions;
+#if PHP_VERSION_ID >= 80300
+	ecma_ce_IntlSupportedLocalesOptions->default_object_handlers = &ecma_handlers_IntlOptions;
+#endif
+
+	memcpy(&ecma_handlers_IntlOptions, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+
+	ecma_handlers_IntlOptions.offset = XtOffsetOf(ecma_IntlOptions, std);
+	ecma_handlers_IntlOptions.free_obj = ecma_freeIntlOptionsObj;
+
+	return SUCCESS;
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, __construct)
+{
+	zend_string *localeMatcher = NULL;
+	zend_object *localeMatcherObj = NULL;
+	ecma_IntlOptions *intlOptions;
+	zend_object *this;
+	zend_class_entry *stringable = zend_ce_stringable;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_OBJ_OF_CLASS_OR_STR_OR_NULL(localeMatcherObj, stringable, localeMatcher)
+	ZEND_PARSE_PARAMETERS_END();
+
+	intlOptions = ECMA_OPTIONS_P(getThis());
+	this = &intlOptions->std;
+
+	setLocaleMatcher(this, localeMatcher, localeMatcherObj);
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, jsonSerialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	serializeObjectProperties(return_value, getThis(), false);
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, current)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	ecma_getCurrentOptionValue(return_value, getThis(), false);
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, key)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	ecma_getCurrentOptionKey(return_value, getThis(), false);
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, next)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	ecma_nextOption(getThis(), false);
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, rewind)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	ecma_rewindOptions(getThis());
+}
+
+PHP_METHOD(Ecma_Intl_SupportedLocales_Options, valid)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	if (!ecma_endOfOptions(getThis(), false)) {
+		RETURN_TRUE;
+	}
+
+	RETURN_FALSE;
+}
+
+static bool isLocaleMatcherAlgorithm(const char *value)
+{
+	return strcmp(value, "lookup") == 0 || strcmp(value, "best fit") == 0;
+}
+
+static void setLocaleMatcher(zend_object *object, zend_string *paramStr, zend_object *paramObj)
+{
+	if (!setStringPropertyFromStringOrStringable(ecma_ce_IntlSupportedLocalesOptions, object, "localeMatcher", paramStr,
+	                                             paramObj, isLocaleMatcherAlgorithm)) {
+		zend_value_error("localeMatcher must be either \"lookup\" or \"best fit\"");
+	}
+}

--- a/src/php/classes/supported_locales_options.h
+++ b/src/php/classes/supported_locales_options.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#ifndef ECMA_INTL_PHP_CLASSES_SUPPORTED_LOCALES_OPTIONS_H
+#define ECMA_INTL_PHP_CLASSES_SUPPORTED_LOCALES_OPTIONS_H
+
+#include "php/php_common.h"
+
+#include "php/classes/options.h"
+
+extern zend_class_entry *ecma_ce_IntlSupportedLocalesOptions;
+
+PHP_MINIT_FUNCTION(ecma_intl_supported_locales_options);
+
+#endif /* ECMA_INTL_PHP_CLASSES_SUPPORTED_LOCALES_OPTIONS_H */

--- a/src/php/classes/supported_locales_options.stub.php
+++ b/src/php/classes/supported_locales_options.stub.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ *
+ * @generate-class-entries
+ */
+
+namespace Ecma\Intl\SupportedLocales
+{
+    /**
+     * Options to use when evaluating supported locales.
+     *
+     * @link https://tc39.es/ecma402/#sec-supportedlocales ECMA-402, section 9.2.10, SupportedLocales
+     *
+     * @strict-properties
+     */
+    readonly class Options implements \Iterator, \JsonSerializable
+    {
+        /**
+         * The locale-matching algorithm to use when evaluating supported locales.
+         */
+        public readonly ?string $localeMatcher;
+
+        /**
+         * Options to use when evaluating supported locales.
+         *
+         * @link https://tc39.es/ecma402/#sec-supportedlocales ECMA-402, section 9.2.10, SupportedLocales
+         *
+         * @param \Stringable|string|null $localeMatcher The locale-matching algorithm to use when evaluating supported locales.
+         */
+        public function __construct(
+            \Stringable|string|null $localeMatcher = null,
+        ) {
+        }
+
+        /**
+         * Returns an object of these options, suitable for serializing to JSON.
+         *
+         * @return object
+         */
+        public function jsonSerialize(): object
+        {
+        }
+
+        public function current(): string|bool
+        {
+        }
+
+        public function next(): void
+        {
+        }
+
+        public function key(): string
+        {
+        }
+
+        public function valid(): bool
+        {
+        }
+
+        public function rewind(): void
+        {
+        }
+    }
+}

--- a/src/php/classes/supported_locales_options_arginfo.h
+++ b/src/php/classes/supported_locales_options_arginfo.h
@@ -1,0 +1,62 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 04f145fc83e7d7e5db1575064f9dd04e535ff1f5 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options___construct, 0, 0, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, localeMatcher, Stringable, MAY_BE_STRING|MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options_jsonSerialize, 0, 0, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options_current, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options_next, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options_key, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Ecma_Intl_SupportedLocales_Options_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Ecma_Intl_SupportedLocales_Options_rewind arginfo_class_Ecma_Intl_SupportedLocales_Options_next
+
+
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, __construct);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, jsonSerialize);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, current);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, next);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, key);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, valid);
+ZEND_METHOD(Ecma_Intl_SupportedLocales_Options, rewind);
+
+
+static const zend_function_entry class_Ecma_Intl_SupportedLocales_Options_methods[] = {
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, __construct, arginfo_class_Ecma_Intl_SupportedLocales_Options___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, jsonSerialize, arginfo_class_Ecma_Intl_SupportedLocales_Options_jsonSerialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, current, arginfo_class_Ecma_Intl_SupportedLocales_Options_current, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, next, arginfo_class_Ecma_Intl_SupportedLocales_Options_next, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, key, arginfo_class_Ecma_Intl_SupportedLocales_Options_key, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, valid, arginfo_class_Ecma_Intl_SupportedLocales_Options_valid, ZEND_ACC_PUBLIC)
+	ZEND_ME(Ecma_Intl_SupportedLocales_Options, rewind, arginfo_class_Ecma_Intl_SupportedLocales_Options_rewind, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Ecma_Intl_SupportedLocales_Options(zend_class_entry *class_entry_Iterator, zend_class_entry *class_entry_JsonSerializable)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Ecma\\Intl\\SupportedLocales", "Options", class_Ecma_Intl_SupportedLocales_Options_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES|ZEND_ACC_READONLY_CLASS;
+	zend_class_implements(class_entry, 2, class_entry_Iterator, class_entry_JsonSerializable);
+
+	zval property_localeMatcher_default_value;
+	ZVAL_UNDEF(&property_localeMatcher_default_value);
+	zend_string *property_localeMatcher_name = zend_string_init("localeMatcher", sizeof("localeMatcher") - 1, 1);
+	zend_declare_typed_property(class_entry, property_localeMatcher_name, &property_localeMatcher_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_localeMatcher_name);
+
+	return class_entry;
+}

--- a/src/php/ecma_intl.c
+++ b/src/php/ecma_intl.c
@@ -24,6 +24,7 @@
 #include "php/classes/locale_text_info.h"
 #include "php/classes/locale_week_day.h"
 #include "php/classes/locale_week_info.h"
+#include "php/classes/supported_locales_options.h"
 
 #include <ext/standard/info.h>
 #include <unicode/ucal.h>
@@ -56,6 +57,7 @@ PHP_MINIT_FUNCTION(ecma_intl_all)
 	PHP_MINIT(ecma_intl_locale_textinfo)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_locale_weekday)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_locale_weekinfo)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(ecma_intl_supported_locales_options)(INIT_FUNC_ARGS_PASSTHRU);
 
 	return SUCCESS;
 }

--- a/src/php/ecma_intl.c
+++ b/src/php/ecma_intl.c
@@ -17,6 +17,7 @@
 #include "php/ecma_intl.h"
 
 #include "php/classes/category.h"
+#include "php/classes/collator.h"
 #include "php/classes/intl.h"
 #include "php/classes/locale.h"
 #include "php/classes/locale_character_direction.h"
@@ -51,6 +52,7 @@ PHP_MINIT_FUNCTION(ecma_intl_all)
 {
 	PHP_MINIT(ecma_intl)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_category)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(ecma_intl_collator)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_locale)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_locale_character_direction)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(ecma_intl_locale_options)(INIT_FUNC_ARGS_PASSTHRU);

--- a/src/php/supported_locales.c
+++ b/src/php/supported_locales.c
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#include "php/supported_locales.h"
+
+#include "ecma402/locale.h"
+#include "php/classes/supported_locales_options.h"
+
+#include <ext/spl/spl_iterators.h>
+#include <unicode/uloc.h>
+
+int ecma_bestFitSupportedLocales(zval *rv, char **availableLocales, int availableLocalesLength, char **requestedLocales,
+                                 int requestedLocalesLength)
+{
+	return ecma_lookupSupportedLocales(rv, availableLocales, availableLocalesLength, requestedLocales,
+	                                   requestedLocalesLength);
+}
+
+int ecma_lookupSupportedLocales(zval *rv, char **availableLocales, int availableLocalesLength, char **requestedLocales,
+                                int requestedLocalesLength)
+{
+	int i, added = 0;
+
+	for (i = 0; i < requestedLocalesLength; i++) {
+		char *bestAvailable = (char *)emalloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
+		if (ecma402_bestAvailableLocale(availableLocales, availableLocalesLength, requestedLocales[i], bestAvailable,
+		                                true) > 0) {
+			add_next_index_string(rv, requestedLocales[i]);
+			added++;
+		}
+		efree(bestAvailable);
+	}
+
+	return added;
+}
+
+void ecma_supportedLocalesOf(zend_execute_data *execute_data, zval *return_value)
+{
+	zval *localesArg, *loopItem;
+	HashTable *localesHt;
+	const char **locales;
+	char **canonicalized, **availableLocales;
+	int canonicalizedLength, availableLocalesLength, localesLength = 0;
+	ecma402_errorStatus *errorStatus;
+	zend_object *options = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+	Z_PARAM_ZVAL(localesArg)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_OBJ_OF_CLASS_OR_NULL(options, ecma_ce_IntlSupportedLocalesOptions)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!isString(localesArg) && !isNull(localesArg) && !isStringable(localesArg) && !isIterable(localesArg)) {
+		zend_argument_type_error(1,
+		                         "must be of type iterable<Stringable|string>|Stringable|string|null, "
+		                         "%s given",
+		                         zend_zval_type_name(localesArg));
+		RETURN_THROWS();
+	}
+
+	array_init(return_value);
+
+	if (EXPECTED(Z_TYPE_P(localesArg) == IS_NULL)) {
+		return;
+	}
+
+	ALLOC_HASHTABLE(localesHt);
+	zend_hash_init(localesHt, 0, NULL, ZVAL_PTR_DTOR, 0);
+
+	if (isString(localesArg)) {
+		zval localeString;
+		ZVAL_STR_COPY(&localeString, Z_STR_P(localesArg));
+		zend_hash_next_index_insert(localesHt, &localeString);
+	} else if (isStringable(localesArg)) {
+		zval localeString;
+		zend_std_cast_object_tostring(Z_OBJ_P(localesArg), &localeString, IS_STRING);
+		zend_hash_next_index_insert(localesHt, &localeString);
+	} else if (isArray(localesArg)) {
+		zend_hash_copy(localesHt, Z_ARRVAL_P(localesArg), (copy_ctor_func_t)zval_add_ref);
+	} else {
+		spl_iterator_apply(localesArg, iteratorToHashTable, (void *)localesHt);
+	}
+
+	locales = (const char **)emalloc(sizeof(char *) * ULOC_FULLNAME_CAPACITY);
+
+	ZEND_HASH_FOREACH_VAL(localesHt, loopItem)
+
+	if (isString(loopItem)) {
+		locales[localesLength] = Z_STRVAL_P(loopItem);
+		localesLength++;
+	} else if (isStringable(loopItem)) {
+		zval localeString;
+		zend_std_cast_object_tostring(Z_OBJ_P(loopItem), &localeString, IS_STRING);
+		locales[localesLength] = Z_STRVAL(localeString);
+		localesLength++;
+	} else {
+		zend_string *method = get_active_function_or_method_name();
+		zend_type_error("%s(): Argument #1 ($%s) must be of type "
+		                "iterable<Stringable|string>|Stringable|string|null, %s given in iterable",
+		                ZSTR_VAL(method), get_active_function_arg_name(1), zend_zval_type_name(loopItem));
+		zend_string_free(method);
+	}
+
+	ZEND_HASH_FOREACH_END();
+
+	errorStatus = ecma402_initErrorStatus();
+
+	if (locales) {
+		canonicalized = (char **)emalloc(sizeof(char *) * ULOC_FULLNAME_CAPACITY);
+		canonicalizedLength = ecma402_canonicalizeLocaleList(locales, localesLength, canonicalized, errorStatus);
+
+		if (ecma402_hasError(errorStatus)) {
+			zend_value_error("%s", errorStatus->errorMessage);
+		} else {
+			availableLocales = (char **)emalloc(sizeof(char *) * uloc_countAvailable());
+			availableLocalesLength = ecma402_intlAvailableLocales(availableLocales);
+
+			const char *localeMatcher =
+				ecma_getOptionString(ecma_ce_IntlSupportedLocalesOptions, options, "localeMatcher");
+			if (localeMatcher != NULL && strcmp(localeMatcher, "best fit") == 0) {
+				ecma_bestFitSupportedLocales(return_value, availableLocales, availableLocalesLength, canonicalized,
+				                             canonicalizedLength);
+			} else {
+				ecma_lookupSupportedLocales(return_value, availableLocales, availableLocalesLength, canonicalized,
+				                            canonicalizedLength);
+			}
+
+			efree(availableLocales);
+		}
+
+		efree(canonicalized);
+	}
+
+	efree(locales);
+
+	ecma402_freeErrorStatus(errorStatus);
+
+	zend_hash_destroy(localesHt);
+	FREE_HASHTABLE(localesHt);
+
+	if (EG(exception)) {
+		RETURN_THROWS();
+	}
+}

--- a/src/php/supported_locales.h
+++ b/src/php/supported_locales.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) php-ecma-intl contributors.
+ *
+ * This source file is subject to the BSD-3-Clause license that is bundled with
+ * this package in the file LICENSE and is available at the following web
+ * address: https://opensource.org/license/bsd-3-clause/
+ *
+ * This source file may utilize copyrighted material from third-party open
+ * source projects, the use of which is acknowledged in the NOTICE file bundled
+ * with this package.
+ */
+
+#ifndef ECMA_INTL_PHP_SUPPORTED_LOCALES_H
+#define ECMA_INTL_PHP_SUPPORTED_LOCALES_H
+
+#include "php/php_common.h"
+
+/**
+ * Uses the Best Fit Matcher algorithm to return a subset of requestedLocales
+ * for which a matching locale was found in availableLocales.
+ *
+ * At present, this simply calls ecma_lookupSupportedLocales(); this
+ * implementation does not define a Best Fit Matcher algorithm (neither does
+ * WebKit).
+ *
+ * @link https://tc39.es/ecma402/#sec-bestfitsupportedlocales
+ * @link
+ * https://github.com/WebKit/WebKit/blob/c734176258bc8893f77db22bb27f668485b53671/Source/JavaScriptCore/runtime/IntlObject.cpp#L1046-L1053
+ *
+ * @param rv A zval (usually return_value) already initialized as a PHP array for storing matched locales.
+ * @param availableLocales An array of locales available to this implementation.
+ * @param availableLocalesLength The number of items in availableLocales.
+ * @param requestedLocales An array of the requested locales to match.
+ * @param requestedLocalesLength The number of items in requestedLocales.
+ *
+ * @return The number of items added to rv.
+ */
+int ecma_bestFitSupportedLocales(zval *rv, char **availableLocales, int availableLocalesLength, char **requestedLocales,
+                                 int requestedLocalesLength);
+
+/**
+ * Uses the BCP 47 Lookup algorithm to return a subset of requestedLocales
+ * for which a matching locale was found in availableLocales.
+ *
+ * @link https://tc39.es/ecma402/#sec-lookupsupportedlocales
+ * @link https://www.rfc-editor.org/rfc/rfc4647.html#section-3.4
+ *
+ * @param rv A zval (usually return_value) already initialized as a PHP array for storing matched locales.
+ * @param availableLocales An array of locales available to this implementation.
+ * @param availableLocalesLength The number of items in availableLocales.
+ * @param requestedLocales An array of the requested locales to match.
+ * @param requestedLocalesLength The number of items in requestedLocales.
+ *
+ * @return The number of items added to rv.
+ */
+int ecma_lookupSupportedLocales(zval *rv, char **availableLocales, int availableLocalesLength, char **requestedLocales,
+                                int requestedLocalesLength);
+
+/**
+ * Handles calls to supportedLocalesOf() static methods on various Ecma\\Intl classes.
+ */
+void ecma_supportedLocalesOf(zend_execute_data *execute_data, zval *return_value);
+
+#endif /* ECMA_INTL_PHP_SUPPORTED_LOCALES_H */

--- a/tests/criterion/ecma402/locale_test.c
+++ b/tests/criterion/ecma402/locale_test.c
@@ -6,6 +6,51 @@
 
 #define TEST_SUITE ecma402Locale
 
+struct bestAvailableTest {
+	char *localeId;
+	bool isCanonicalized;
+	char *expected;
+	int expectedLength;
+};
+
+static int addTest(struct bestAvailableTest *tests, int index, const char *localeId, bool isCanonicalized,
+                   const char *expected, int expectedLength)
+{
+	if (localeId == NULL) {
+		tests[index].localeId = NULL;
+	} else {
+		tests[index].localeId = testStrDup(localeId);
+	}
+
+	tests[index].isCanonicalized = isCanonicalized;
+
+	if (expected == NULL) {
+		tests[index].expected = NULL;
+	} else {
+		tests[index].expected = testStrDup(expected);
+	}
+
+	tests[index].expectedLength = expectedLength;
+
+	return ++index;
+}
+
+void freeTests(struct criterion_test_params *criterionParams)
+{
+	struct bestAvailableTest *tests = (struct bestAvailableTest *)criterionParams->params;
+
+	for (size_t i = 0; i < criterionParams->length; ++i) {
+		if (tests[i].localeId != NULL) {
+			cr_free(tests[i].localeId);
+		}
+		if (tests[i].expected != NULL) {
+			cr_free(tests[i].expected);
+		}
+	}
+
+	cr_free(tests);
+}
+
 Test(TEST_SUITE, keywordsOfLocaleReturnsZeroForUnknownKeyword)
 {
 	ecma402_locale *locale = ecma402_initLocale("foobar");
@@ -13,33 +58,90 @@ Test(TEST_SUITE, keywordsOfLocaleReturnsZeroForUnknownKeyword)
 	ecma402_freeLocale(locale);
 }
 
-Test(TEST_SUITE, intlAvailableLocales) {
-  char **locales;
-  int count;
-  bool foundEn = false, foundDe = false, foundFr = false, foundZh = false;
+Test(TEST_SUITE, intlAvailableLocales)
+{
+	char **locales;
+	int count;
+	bool foundEn = false, foundDe = false, foundFr = false, foundZh = false;
 
-  locales = (char **)malloc(sizeof(char *) * uloc_countAvailable());
-  count = ecma402_intlAvailableLocales(locales);
+	locales = (char **)malloc(sizeof(char *) * uloc_countAvailable());
+	count = ecma402_intlAvailableLocales(locales);
 
-  cr_assert(gt(i16, count, 0));
+	cr_assert(gt(i16, count, 0));
 
-  // Search for a few well-known locales that should be included.
-  for (int i = 0; i < count; i++) {
-    if (strcmp(locales[i], "en") == 0) {
-      foundEn = true;
-    } else if (strcmp(locales[i], "de") == 0) {
-      foundDe = true;
-    } else if (strcmp(locales[i], "fr") == 0) {
-      foundFr = true;
-    } else if (strcmp(locales[i], "zh") == 0) {
-      foundZh = true;
-    }
-  }
+	// Search for a few well-known locales that should be included.
+	for (int i = 0; i < count; i++) {
+		if (strcmp(locales[i], "en") == 0) {
+			foundEn = true;
+		} else if (strcmp(locales[i], "de") == 0) {
+			foundDe = true;
+		} else if (strcmp(locales[i], "fr") == 0) {
+			foundFr = true;
+		} else if (strcmp(locales[i], "zh") == 0) {
+			foundZh = true;
+		}
+	}
 
-  cr_expect(eq(i8, foundEn, true));
-  cr_expect(eq(i8, foundDe, true));
-  cr_expect(eq(i8, foundFr, true));
-  cr_expect(eq(i8, foundZh, true));
+	cr_expect(eq(i8, foundEn, true));
+	cr_expect(eq(i8, foundDe, true));
+	cr_expect(eq(i8, foundFr, true));
+	cr_expect(eq(i8, foundZh, true));
 
-  free(locales);
+	free(locales);
+}
+
+ParameterizedTestParameters(TEST_SUITE, bestAvailableLocale)
+{
+	struct bestAvailableTest *tests;
+	int idx = 0;
+
+	tests = (struct bestAvailableTest *)cr_malloc(sizeof(struct bestAvailableTest) * 100);
+	idx = addTest(tests, idx, NULL, true, NULL, -1);
+	idx = addTest(tests, idx, NULL, false, NULL, -1);
+	idx = addTest(tests, idx, "", true, NULL, -1);
+	idx = addTest(tests, idx, "", false, NULL, -1);
+	idx = addTest(tests, idx, "en-US", true, "en-US", 5);
+	idx = addTest(tests, idx, "en-US", false, "en-US", 5);
+	idx = addTest(tests, idx, "en-GB", true, "en-GB", 5);
+	idx = addTest(tests, idx, "en-GB", false, "en-GB", 5);
+	idx = addTest(tests, idx, "en", true, "en", 2);
+	idx = addTest(tests, idx, "en", false, "en", 2);
+	idx = addTest(tests, idx, "en_US", true, NULL, -1);
+	idx = addTest(tests, idx, "en_US", false, "en-US", 5);
+	idx = addTest(tests, idx, "en-Latn-US", true, "en", 2);
+	idx = addTest(tests, idx, "en-Latn-US", false, "en", 2);
+	idx = addTest(tests, idx, "xx-XX", true, NULL, -1);
+	idx = addTest(tests, idx, "xx-XX", false, NULL, -1);
+	idx = addTest(tests, idx, "xx", true, NULL, -1);
+	idx = addTest(tests, idx, "xx", false, NULL, -1);
+	idx = addTest(tests, idx, "foobarbaz", true, NULL, -1);
+	idx = addTest(tests, idx, "foobarbaz", false, NULL, -1);
+	idx = addTest(tests, idx, "en-US-u-ca-gregory-co-emoji", true, "en-US", 5);
+	idx = addTest(tests, idx, "en-US-u-ca-gregory-co-emoji", false, "en-US", 5);
+	idx = addTest(tests, idx, "en_US@calendar=gregory;collation=emoji", true, NULL, -1);
+	idx = addTest(tests, idx, "en_US@calendar=gregory;collation=emoji", false, "en-US", 5);
+	idx = addTest(tests, idx, "hi-t-en-h0-hybrid", true, "hi", 2);
+	idx = addTest(tests, idx, "hi-Latn-t-en-h0-hybrid", true, "hi-Latn", 7);
+
+	return cr_make_param_array(struct bestAvailableTest, tests, idx, freeTests);
+}
+
+ParameterizedTest(struct bestAvailableTest *test, TEST_SUITE, bestAvailableLocale)
+{
+	char **available = (char **)malloc(sizeof(char *) * uloc_countAvailable());
+	int count = ecma402_intlAvailableLocales(available);
+
+	char *result = (char *)malloc(sizeof(char) * ULOC_FULLNAME_CAPACITY);
+	int resultLength = ecma402_bestAvailableLocale(available, count, test->localeId, result, test->isCanonicalized);
+
+	cr_expect(eq(i8, resultLength, test->expectedLength), "Expected length of %d for localeId \"%s\"; received %d",
+	          test->expectedLength, test->localeId, resultLength);
+
+	if (test->expected != NULL) {
+		cr_expect(eq(str, result, test->expected), "Expected value of \"%s\" for localeId \"%s\"; received \"%s\"",
+		          test->expected, test->localeId, result);
+	}
+
+	free(result);
+	free(available);
 }

--- a/tests/criterion/ecma402/locale_test.c
+++ b/tests/criterion/ecma402/locale_test.c
@@ -12,3 +12,34 @@ Test(TEST_SUITE, keywordsOfLocaleReturnsZeroForUnknownKeyword)
 	cr_expect(eq(int, ecma402_keywordsOfLocale(locale, "unknown", NULL), 0));
 	ecma402_freeLocale(locale);
 }
+
+Test(TEST_SUITE, intlAvailableLocales) {
+  char **locales;
+  int count;
+  bool foundEn = false, foundDe = false, foundFr = false, foundZh = false;
+
+  locales = (char **)malloc(sizeof(char *) * uloc_countAvailable());
+  count = ecma402_intlAvailableLocales(locales);
+
+  cr_assert(gt(i16, count, 0));
+
+  // Search for a few well-known locales that should be included.
+  for (int i = 0; i < count; i++) {
+    if (strcmp(locales[i], "en") == 0) {
+      foundEn = true;
+    } else if (strcmp(locales[i], "de") == 0) {
+      foundDe = true;
+    } else if (strcmp(locales[i], "fr") == 0) {
+      foundFr = true;
+    } else if (strcmp(locales[i], "zh") == 0) {
+      foundZh = true;
+    }
+  }
+
+  cr_expect(eq(i8, foundEn, true));
+  cr_expect(eq(i8, foundDe, true));
+  cr_expect(eq(i8, foundFr, true));
+  cr_expect(eq(i8, foundZh, true));
+
+  free(locales);
+}

--- a/tests/criterion/ecma402/locale_test.c
+++ b/tests/criterion/ecma402/locale_test.c
@@ -121,7 +121,6 @@ ParameterizedTestParameters(TEST_SUITE, bestAvailableLocale)
 	idx = addTest(tests, idx, "en_US@calendar=gregory;collation=emoji", true, NULL, -1);
 	idx = addTest(tests, idx, "en_US@calendar=gregory;collation=emoji", false, "en-US", 5);
 	idx = addTest(tests, idx, "hi-t-en-h0-hybrid", true, "hi", 2);
-	idx = addTest(tests, idx, "hi-Latn-t-en-h0-hybrid", true, "hi-Latn", 7);
 
 	return cr_make_param_array(struct bestAvailableTest, tests, idx, freeTests);
 }

--- a/tests/criterion/test.h
+++ b/tests/criterion/test.h
@@ -16,6 +16,10 @@
 
 #define END_STRING_TEST_PARAMS return cr_make_param_array(stringTestParams, tests, index, freeStringTestParams)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct stringTestParams stringTestParams;
 
 struct stringTestParams {
@@ -27,5 +31,9 @@ int addStringTest(stringTestParams *tests, int index, const char *input, const c
 void freeStringTestParams(struct criterion_test_params *criterionParams);
 char *testStrDup(const char *str);
 void testFreeStrings(struct criterion_test_params *criterionParams);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ECMA_INTL_TESTS_CRITERION_TEST_H */

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-001.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-001.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Collator::supportedLocalesOf returns supported locales
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$newStringable = function (string $value): object {
+    return new class ($value) {
+        public function __construct(private readonly string $value)
+        {
+        }
+        
+        public function __toString(): string
+        {
+            return $this->value;
+        }
+    };
+};
+
+$result = Collator::supportedLocalesOf(
+    [
+        'en-US',
+        'foobar',
+        $newStringable('en-US'),
+        'en-Latn-US',
+        $newStringable('en-Latn-US'),
+        'ban',
+        'de',
+        $newStringable('ban'),
+        'en-GB',
+    ],
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'en-US',
+  1 => 'en-Latn-US',
+  2 => 'de',
+  3 => 'en-GB',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-002.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-002.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Collator::supportedLocalesOf uses "best fit" matcher
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+use Ecma\Intl\SupportedLocales\Options;
+
+$result = Collator::supportedLocalesOf(
+    [
+        'ban',
+        'de',
+        'en-US-u-co-emoji-ca-gregory',
+        'en-GB',
+        'en-Latn-US',
+    ],
+    new Options(localeMatcher: 'best fit'),
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'de',
+  1 => 'en-US-u-ca-gregory-co-emoji',
+  2 => 'en-GB',
+  3 => 'en-Latn-US',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-003.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-003.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Collator::supportedLocalesOf uses "lookup" matcher
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+use Ecma\Intl\SupportedLocales\Options;
+
+$newStringable = function (string $value): object {
+    return new class ($value) {
+        public function __construct(private readonly string $value)
+        {
+        }
+        
+        public function __toString(): string
+        {
+            return $this->value;
+        }
+    };
+};
+
+$result = Collator::supportedLocalesOf(
+    [
+        $newStringable('ban'),
+        $newStringable('de'),
+        $newStringable('en-US-u-co-emoji-ca-gregory'),
+        $newStringable('en-GB'),
+        $newStringable('en-Latn-US'),
+    ],
+    new Options(localeMatcher: 'lookup'),
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'de',
+  1 => 'en-US-u-ca-gregory-co-emoji',
+  2 => 'en-GB',
+  3 => 'en-Latn-US',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-004.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-004.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Collator::supportedLocalesOf with a single Stringable
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$newStringable = function (string $value): object {
+    return new class ($value) {
+        public function __construct(private readonly string $value)
+        {
+        }
+        
+        public function __toString(): string
+        {
+            return $this->value;
+        }
+    };
+};
+
+$result = Collator::supportedLocalesOf(
+    $newStringable('de-de-u-cu-EUR-ca-buddhist'),
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'de-DE-u-ca-buddhist-cu-eur',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-005.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-005.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Collator::supportedLocalesOf with a single string
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$result = Collator::supportedLocalesOf(
+    'de-DE-POSIX',
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'de-DE-u-va-posix',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-006.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-006.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Collator::supportedLocalesOf with no matching locales
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$result = Collator::supportedLocalesOf(
+    'ban',
+);
+
+var_export($result);
+
+--EXPECT--
+array (
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-007.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-007.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Collator::supportedLocalesOf with an empty array
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$result = Collator::supportedLocalesOf([]);
+
+var_export($result);
+
+--EXPECT--
+array (
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-008.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-008.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Collator::supportedLocalesOf with a NULL value
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$result = Collator::supportedLocalesOf(null);
+
+var_export($result);
+
+--EXPECT--
+array (
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-009.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-009.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Collator::supportedLocalesOf with invalid values
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$tests = [
+    123,
+    12.3,
+    false,
+    (object) [],
+    ['en-US', 'fr', 123, 'de'],
+    ['en-US', 123, 12.3, 'de'],
+    ['en-US', 123, null, 'de'],
+    ['en-US', 123, (object) [], 'de'],
+    (function (): Generator {
+        yield 'en-US';
+        yield 'fr';
+        yield null;
+        yield 'de';
+    })(),
+];
+
+foreach ($tests as $test) {
+    try {
+        Collator::supportedLocalesOf($test);
+    } catch (Throwable $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+--EXPECT--
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, int given
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, float given
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, bool given
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, stdClass given
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, int given in iterable
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, float given in iterable
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, null given in iterable
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, stdClass given in iterable
+Ecma\Intl\Collator::supportedLocalesOf(): Argument #1 ($locales) must be of type iterable<Stringable|string>|Stringable|string|null, null given in iterable

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-010.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-010.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Collator::supportedLocalesOf with a Generator
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$func = function (): Generator {
+    yield 'en-US';
+    yield 'fr';
+    yield 'de';
+    yield 'es-MX';
+};
+
+$generator = $func();
+
+$result = Collator::supportedLocalesOf($generator);
+
+var_export($result);
+
+--EXPECT--
+array (
+  0 => 'en-US',
+  1 => 'fr',
+  2 => 'de',
+  3 => 'es-MX',
+)

--- a/tests/phpt/Intl/Collator_supportedLocalesOf-011.phpt
+++ b/tests/phpt/Intl/Collator_supportedLocalesOf-011.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Collator::supportedLocalesOf with invalid locale
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\Collator;
+
+$tests = [
+    'foo-bar-baz',
+];
+
+foreach ($tests as $test) {
+    try {
+        Collator::supportedLocalesOf($test);
+    } catch (Throwable $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+}
+
+--EXPECT--
+Invalid language tag "foo-bar-baz"

--- a/tests/phpt/Intl/SupportedLocales/Options-001.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+SupportedLocales\Options without any parameters serializes to empty JSON object
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options = new Options();
+
+var_export($options);
+echo "\n\n";
+echo json_encode($options);
+echo "\n";
+
+--EXPECT--
+\Ecma\Intl\SupportedLocales\Options::__set_state(array(
+   'localeMatcher' => NULL,
+))
+
+{}

--- a/tests/phpt/Intl/SupportedLocales/Options-002.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-002.phpt
@@ -1,0 +1,25 @@
+--TEST--
+SupportedLocales\Options with all parameters serializes to full JSON object
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options = new Options(
+    localeMatcher: 'best fit',
+);
+
+var_export($options);
+echo "\n\n";
+echo json_encode($options);
+echo "\n";
+
+--EXPECT--
+\Ecma\Intl\SupportedLocales\Options::__set_state(array(
+   'localeMatcher' => 'best fit',
+))
+
+{"localeMatcher":"best fit"}

--- a/tests/phpt/Intl/SupportedLocales/Options-003.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-003.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SupportedLocales\Options can access each property
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options = new Options(
+    localeMatcher: 'lookup',
+);
+
+var_dump($options->localeMatcher);
+
+--EXPECT--
+string(6) "lookup"

--- a/tests/phpt/Intl/SupportedLocales/Options-004.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-004.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SupportedLocales\Options can set each property to null
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options = new Options(
+    localeMatcher: null,
+);
+
+var_dump($options->localeMatcher);
+
+--EXPECT--
+NULL

--- a/tests/phpt/Intl/SupportedLocales/Options-005.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-005.phpt
@@ -1,0 +1,28 @@
+--TEST--
+SupportedLocales\Options properties are readonly
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$properties = [
+    'localeMatcher' => 'best fit',
+];
+
+$options = new Options();
+
+foreach ($properties as $property => $value) {
+    assert($options->{$property} === null);
+    
+    try {
+        $options->{$property} = $value;
+    } catch (Error $error) {
+        echo $error->getMessage() . "\n";
+    }
+}
+
+--EXPECT--
+Cannot modify readonly property Ecma\Intl\SupportedLocales\Options::$localeMatcher

--- a/tests/phpt/Intl/SupportedLocales/Options-006.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-006.phpt
@@ -1,0 +1,26 @@
+--TEST--
+SupportedLocales\Options throws exceptions for invalid values
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$tests = [
+    ['localeMatcher', 'abcd'],        // wrong value
+];
+
+
+foreach ($tests as $test) {
+    [$property, $value] = $test;
+    try {
+        $options = new Options(...[$property => $value]);
+    } catch (Error $error) {
+        echo $error->getMessage() . "\n";
+    }
+}
+
+--EXPECT--
+localeMatcher must be either "lookup" or "best fit"

--- a/tests/phpt/Intl/SupportedLocales/Options-007.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-007.phpt
@@ -1,0 +1,19 @@
+--TEST--
+SupportedLocales\Options can be combined with array unpacking
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options1 = new Options(localeMatcher: 'best fit');
+$options2 = new Options(localeMatcher: 'lookup');
+
+echo json_encode(new Options(...[...$options1, ...$options2])) . "\n";
+echo json_encode(new Options(...[...$options2, ...$options1])) . "\n";
+
+--EXPECT--
+{"localeMatcher":"lookup"}
+{"localeMatcher":"best fit"}

--- a/tests/phpt/Intl/SupportedLocales/Options-008.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-008.phpt
@@ -1,0 +1,38 @@
+--TEST--
+SupportedLocales\Options with stringable parameters
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$newStringable = function (string $value): object {
+    return new class ($value) {
+        public function __construct(private readonly string $value)
+        {
+        }
+        
+        public function __toString(): string
+        {
+            return $this->value;
+        }
+    };
+};
+
+$options = new Options(
+    localeMatcher: $newStringable('lookup'),
+);
+
+var_export($options);
+echo "\n\n";
+echo json_encode($options);
+echo "\n";
+
+--EXPECT--
+\Ecma\Intl\SupportedLocales\Options::__set_state(array(
+   'localeMatcher' => 'lookup',
+))
+
+{"localeMatcher":"lookup"}

--- a/tests/phpt/Intl/SupportedLocales/Options-009.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-009.phpt
@@ -1,0 +1,43 @@
+--TEST--
+SupportedLocales\Options propagates exceptions thrown from stringable conversion
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+class CustomError extends RuntimeException
+{
+}
+
+$throwingStringable = function (string $property): object {
+    return new class ($property) {
+        public function __construct(private readonly string $property)
+        {
+        }
+ 
+        public function __toString(): string
+        {
+            throw new CustomError('problem with string conversion for ' . $this->property);
+        }
+    };
+};
+
+$properties = [
+    'localeMatcher' => $throwingStringable('localeMatcher'),
+];
+
+foreach ($properties as $property => $value) {
+    assert($value instanceof Stringable);
+
+    try {
+        new Options(...[$property => $value]);
+    } catch (Throwable $exception) {
+        echo $exception::class . ' - ' . $exception->getMessage() . "\n";
+    }
+}
+
+--EXPECT--
+CustomError - problem with string conversion for localeMatcher

--- a/tests/phpt/Intl/SupportedLocales/Options-010.phpt
+++ b/tests/phpt/Intl/SupportedLocales/Options-010.phpt
@@ -1,0 +1,20 @@
+--TEST--
+SupportedLocales\Options supports full array unpacking
+--EXTENSIONS--
+ecma_intl
+--FILE--
+<?php
+declare(strict_types=1);
+
+use Ecma\Intl\SupportedLocales\Options;
+
+$options = new Options(
+    localeMatcher: 'best fit',
+);
+
+var_export([...$options]);
+
+--EXPECT--
+array (
+  'localeMatcher' => 'best fit',
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR implements the following functionality from ECMA-402:

- [LookupSupportedLocales](https://tc39.es/ecma402/#sec-lookupsupportedlocales)
- [BestFitSupportedLocales](https://tc39.es/ecma402/#sec-bestfitsupportedlocales)
- [SupportedLocales](https://tc39.es/ecma402/#sec-supportedlocales)
- [Intl.Collator.supportedLocalesOf](https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof)

## Motivation and context
ECMA-402 defines the `supportedLocalesOf()` static method as a property of many of the constructors available under `Intl`.

## How has this been tested?
Unit and functional tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
